### PR TITLE
Fix compiler error with visual studio.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,7 +471,7 @@ fips_begin_app(21-deferred cmdline)
     fips_deps(bgfx bgfx-3rdparty bgfx-examples-common)
 fips_end_app()
 
-fips_begin_app(22-cmdline cmdline)
+fips_begin_app(22-windows cmdline)
     fips_dir(bgfx/examples/22-windows GROUP ".")
     fips_files(windows.cpp)
     fips_deps(bgfx bgfx-3rdparty bgfx-examples-common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ elseif (FIPS_IOS)
 elseif (FIPS_PNACL)
     include_directories(bx/include/compat/nacl)
 elseif (FIPS_WINDOWS)
+    add_definitions(-D__STDC_FORMAT_MACROS)
     include_directories(bx/include/compat/msvc)
 endif()
 

--- a/fips.yml
+++ b/fips.yml
@@ -43,7 +43,7 @@ run:
         cwd: bgfx/examples/runtime
     21-deferred:
         cwd: bgfx/examples/runtime
-    22-windowed:
+    22-windows:
         cwd: bgfx/examples/runtime
     23-vectordisplay:
         cwd: bgfx/examples/runtime

--- a/fips.yml
+++ b/fips.yml
@@ -57,6 +57,5 @@ exports:
         - bgfx/include
         - bgfx/examples/common
         - bx/include
-        - bx/include/compat/msvc
     modules:
         bgfx: .

--- a/fips.yml
+++ b/fips.yml
@@ -55,7 +55,8 @@ run:
 exports:
     header-dirs:
         - bgfx/include
-        - bx/include
         - bgfx/examples/common
+        - bx/include
+        - bx/include/compat/msvc
     modules:
         bgfx: .


### PR DESCRIPTION
I've missed this define on my cleanup. It is needed because when including inttypes.h the needed definitions are excluded by a !defined(__cplusplus).
