### PR TITLE
Implements auxiliary fips function bgfx_app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,15 +34,12 @@ if (NOT CMAKE_TOOLCHAIN_FILE)
 fips_ide_group(Tools)
 fips_begin_app(shaderc cmdline)
     fips_include_directories(bgfx/3rdparty/glsl-optimizer/src/glsl)
-    fips_dir(bgfx/tools/shaderc GROUP "shaderc")
-    fips_files(shaderc.cpp shaderc.h shaderc_glsl.cpp shaderc_hlsl.cpp)
-    fips_dir(bgfx/src GROUP "bgfx")
-    fips_files(vertexdecl.cpp vertexdecl.h)
+    fips_src(bgfx/tools/shaderc GROUP "shaderc")
+    fips_files_ex(bgfx/src vertexdecl.* GROUP "bgfx")
     fips_deps(bgfx-fcpp bgfx-glsl-optimizer)
     if (FIPS_WINDOWS)
         add_definitions(-D__STDC__ -D__STDC_VERSION__=199901L -Dstrdup=_strdup -Dalloca=_alloca -Disascii=__isascii)
         fips_include_directories(bgfx/3rdparty/glsl-optimizer/include/c99)
-        #include_directories($ENV{DXSDK_DIR}include)
         include_directories(bgfx/3rdparty/dxsdk/include)
         set(DXSDK_LIB "$ENV{DXSDK_DIR}Lib\\${FIPS_WINDOWS_PLATFORM_NAME}\\")
         fips_libs(d3dcompiler dxguid)
@@ -50,27 +47,17 @@ fips_begin_app(shaderc cmdline)
 fips_end_app()
 
 fips_begin_app(texturec cmdline)
-    fips_include_directories(bx/include)
-    fips_include_directories(bgfx/include)
-    fips_include_directories(bgfx/src)
-    fips_dir(bgfx/tools/texturec GROUP "texturec")
-    fips_files(texturec.cpp)
-    fips_dir(bgfx/src GROUP "bgfx")
-    fips_files(image.cpp image.h)
+    fips_include_directories(bx/include bgfx/include bgfx/src)
+    fips_src(bgfx/tools/texturec GROUP "texturec")
+    fips_files_ex(bgfx/src image.* GROUP "bgfx")
     fips_deps(bgfx-edtaa3 bgfx-libsquish bgfx-etc1 bgfx-etc2 bgfx-nvtt bgfx-pvrtc bgfx-tinyexr)
 fips_end_app()
 
 fips_begin_app(geometryc cmdline)
-    fips_include_directories(bx/include)
-    fips_include_directories(bgfx/include)
-    fips_include_directories(bgfx/3rdparty)
-    fips_include_directories(bgfx/examples/common)
-    fips_dir(bgfx/tools/geometryc GROUP "geometryc")
-    fips_files(geometryc.cpp)
-    fips_dir(bgfx/src GROUP "bgfx")
-    fips_files(vertexdecl.cpp vertexdecl.h)
-    fips_dir(bgfx/examples/common GROUP "bounds")
-    fips_files(bounds.cpp bounds.h)
+    fips_include_directories(bx/include bgfx/include bgfx/3rdparty bgfx/examples/common)
+    fips_src(bgfx/tools/geometryc GROUP "geometryc")
+    fips_files_ex(bgfx/src vertexdecl.* GROUP "bgfx")
+    fips_files_ex(bgfx/examples/common bounds.* GROUP "bounds")
     fips_deps(bgfx-forsyth bgfx-ib-compress)
 fips_end_app()
 
@@ -91,105 +78,61 @@ fips_ide_group(3rdparty)
 
 fips_begin_lib(bgfx-imgui)
     set_property(DIRECTORY PROPERTY COMPILE_DEFINITIONS "")
-    fips_dir(bgfx/3rdparty/ocornut-imgui)
-    fips_files(
-        imgui.cpp imgui.h imgui_demo.cpp imgui_draw.cpp 
-        imgui_wm.cpp imgui_wm.h imgui_node_graph_test.cpp
-        imconfig.h imgui_internal.h
-        memory_editor.h stb_rect_pack.h stb_textedit.h stb_truetype.h
-    )
+    fips_src(bgfx/3rdparty/ocornut-imgui)
 fips_end_lib()
 
 fips_begin_lib(bgfx-ib-compress)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
-    fips_dir(bgfx/3rdparty/ib-compress)
-    fips_files(
-        indexbuffercompression.cpp indexbuffercompression.h
-        indexbuffercompressionformat.h
-        indexbufferdecompression.cpp indexbufferdecompression.h
-        indexcompressionconstants.h
-        readbitstream.h
-        writebitstream.h
-    )
+    fips_src(bgfx/3rdparty/ib-compress)
 fips_end_lib()
 
 fips_begin_lib(bgfx-tinyexr)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DMINIZ_NO_TIME)
-    fips_dir(bgfx/3rdparty/tinyexr)
-    fips_files(tinyexr.cc tinyexr.h)
+    fips_src(bgfx/3rdparty/tinyexr)
 fips_end_lib()
 
 fips_begin_lib(bgfx-libsquish)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
-    fips_dir(bgfx/3rdparty/libsquish)
-    fips_files(
-        alpha.cpp clusterfit.cpp colourblock.cpp colourfit.cpp colourset.cpp maths.cpp rangefit.cpp 
-        singlecolourfit.cpp squish.cpp
-    )
+    fips_src(bgfx/3rdparty/libsquish)
 fips_end_lib()
 
 fips_begin_lib(bgfx-pvrtc)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
-    fips_dir(bgfx/3rdparty/pvrtc)
-    fips_files(BitScale.cpp MortonTable.cpp PvrTcDecoder.cpp PvrTcEncoder.cpp PvrTcPacket.cpp)
+    fips_src(bgfx/3rdparty/pvrtc)
 fips_end_lib()
 
 fips_begin_lib(bgfx-nvtt)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
     include_directories(bgfx/3rdparty/nvtt)
-    fips_dir(bgfx/3rdparty/nvtt)
-    fips_files(
-        nvtt.cpp
-        nvmath/fitting.cpp
-        bc7/avpcl.cpp
-        bc7/avpcl_mode0.cpp
-        bc7/avpcl_mode1.cpp
-        bc7/avpcl_mode2.cpp
-        bc7/avpcl_mode3.cpp
-        bc7/avpcl_mode4.cpp
-        bc7/avpcl_mode5.cpp
-        bc7/avpcl_mode6.cpp
-        bc7/avpcl_mode7.cpp
-        bc7/avpcl_utils.cpp
-        bc6h/zoh.cpp
-        bc6h/zoh_utils.cpp
-        bc6h/zohone.cpp
-        bc6h/zohtwo.cpp
-    )
+    fips_src(bgfx/3rdparty/nvtt)
 fips_end_lib()
 
 fips_begin_lib(bgfx-etc1)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
-    fips_dir(bgfx/3rdparty/etc1)
-    fips_files(etc1.cpp etc1.h)
+    fips_src(bgfx/3rdparty/etc1)
 fips_end_lib()
 
 fips_begin_lib(bgfx-etc2)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
-    fips_dir(bgfx/3rdparty/etc2)
-    fips_files(Tables.cpp ProcessRGB.cpp Math.hpp ProcessCommon.hpp ProcessRGB.hpp Tables.hpp Types.hpp Vector.hpp)
+    fips_src(bgfx/3rdparty/etc2)
 fips_end_lib()
 
 fips_begin_lib(bgfx-forsyth)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
     include_directories(bgfx/3rdparty/forsyth-too)
-    fips_dir(bgfx/3rdparty/forsyth-too)
-    fips_files(forsythtriangleorderoptimizer.cpp forsythtriangleorderoptimizer.h)
+    fips_src(bgfx/3rdparty/forsyth-too)
 fips_end_lib()
 
 fips_begin_lib(bgfx-edtaa3)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
     include_directories(bgfx/3rdparty/edtaa3)
-    fips_dir(bgfx/3rdparty/edtaa3)
-    fips_files(edtaa3func.cpp)
+    fips_src(bgfx/3rdparty/edtaa3)
 fips_end_lib()
 
 fips_begin_lib(bgfx-fcpp)
     add_definitions(-DNINCLUDE=64 -DNWORK=65536 -DNBUFF=65536 -DOLD_PREPROCESSOR=0 -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
     include_directories(bgfx/3rdparty/fcpp)
-    fips_dir(bgfx/3rdparty/fcpp)
-    fips_files(cpp1.c cpp2.c cpp3.c cpp4.c cpp5.c cpp6.c)
-    fips_files(cpp.h cppadd.h cppdef.h fpp.h fpp_pragmas.h fpp_protos.h fppbase.h)
+    fips_src(bgfx/3rdparty/fcpp EXCEPT usecpp.c)
 fips_end_lib()
 
 fips_begin_lib(bgfx-glsl-optimizer)
@@ -236,56 +179,20 @@ fips_begin_lib(bgfx)
         include_directories(bgfx/3rdparty/khronos)
     endif()
     include_directories(bgfx/3rdparty)
-    fips_dir(bgfx/src GROUP "src")
-    # note: add all files to the build process, bgfx knows
-    # itself what to compile on each platform
-    fips_files(
-        bgfx.cpp bgfx_p.h
-        topology.cpp topology.h
-        charset.h config.h
-        glimports.h
-        glcontext_eagl.h glcontext_eagl.mm
-        glcontext_egl.cpp glcontext_egl.h
-        glcontext_glx.cpp glcontext_glx.h
-        glcontext_nsgl.h glcontext_nsgl.mm
-        glcontext_ppapi.cpp glcontext_ppapi.h
-        glcontext_wgl.cpp glcontext_wgl.h
-        image.cpp image.h
-        ovr.cpp ovr.h
-        renderdoc.cpp renderdoc.h
-        renderer.h renderer_null.cpp
-        renderer_gl.cpp renderer_gl.h
-        renderer_d3d.h
-        renderer_d3d11.cpp renderer_d3d11.h
-        renderer_d3d12.cpp renderer_d3d12.h
-        renderer_d3d9.cpp renderer_d3d9.h
-        renderer_mtl.h renderer_mtl.mm
-        renderer_vk.cpp
-        shader_dx9bc.cpp shader_dx9bc.h
-        shader_dxbc.cpp shader_dxbc.h
-        shader_spirv.cpp shader_spirv.h
-        vertexdecl.cpp vertexdecl.h
-        varying.def.sc
-    )
-
+    fips_src(bgfx/src EXCEPT amalgamated.cpp GROUP "src")
+    fips_files(varying.def.sc)
     bgfx_shaders(FILES
-        fs_clear0.sc
-        fs_clear1.sc
-        fs_clear2.sc
-        fs_clear3.sc
-        fs_clear4.sc
-        fs_clear5.sc
-        fs_clear6.sc
-        fs_clear7.sc
-        fs_debugfont.sc
-        vs_clear.sc
-        vs_debugfont.sc
+        fs_clear0.sc fs_clear1.sc fs_clear2.sc fs_clear3.sc fs_clear4.sc
+        fs_clear5.sc fs_clear6.sc fs_clear7.sc vs_clear.sc
+        fs_debugfont.sc vs_debugfont.sc
     )
 
     if (FIPS_MACOS)
         fips_files(glcontext_nsgl.mm glcontext_nsgl.h)
+        fips_files(renderer_mtl.h renderer_mtl.mm)
     elseif (FIPS_IOS)
         fips_files(glcontext_eagl.mm glcontext_eagl.h)
+        fips_files(renderer_mtl.h renderer_mtl.mm)
     elseif (FIPS_LINUX)
         fips_files(glcontext_glx.cpp glcontext_glx.h)
     elseif (FIPS_PNACL)
@@ -295,17 +202,8 @@ fips_begin_lib(bgfx)
     else()
         fips_files(glcontext_egl.cpp glcontext_egl.h)
     endif()
-    fips_dir(bgfx/include/bgfx GROUP "include")
-    fips_files(
-        c99/bgfx.h
-        c99/bgfxplatform.h
-        bgfx.h
-        bgfxdefines.h
-        bgfxplatform.h
-    )
+    fips_src(bgfx/include/bgfx GROUP "include")
 
-    # untested, note: OSX and iOS currently
-    # automatically link against GL
     if (FIPS_MACOS)
         fips_frameworks_osx(Cocoa IOKit CoreFoundation CoreVideo Carbon OpenGL Metal QuartzCore)
     elseif (FIPS_WINDOWS)
@@ -332,16 +230,8 @@ endif()
 fips_begin_lib(bgfx-examples-common)
     include_directories(bgfx/3rdparty/dxsdk/include)
     add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS)
-    fips_dir(bgfx/examples/common GROUP ".")
-    fips_files(
-        aviwriter.h
-        bgfx_utils.cpp bgfx_utils.h
-        bounds.cpp bounds.h
-        camera.cpp camera.h
-        common.h
-        cube_atlas.cpp cube_atlas.h
-    )
-    fips_dir(bgfx/examples/common/imgui GROUP "imgui")
+    fips_src(bgfx/examples/common GROUP ".")
+    fips_src(bgfx/examples/common/imgui GROUP "imgui")
     bgfx_shaders(FILES
         fs_imgui_color.sc   vs_imgui_color.sc
         fs_imgui_cubemap.sc vs_imgui_cubemap.sc
@@ -350,21 +240,12 @@ fips_begin_lib(bgfx-examples-common)
         fs_ocornut_imgui.sc vs_ocornut_imgui.sc
         fs_imgui_image_swizz.sc
     )
-    fips_files(
-        droidsans.ttf.h
-        imgui.cpp imgui.h
-        ocornut_imgui.cpp ocornut_imgui.h
-        varying.def.sc
-    )
-    fips_dir(bgfx/examples/common/nanovg GROUP "nanovg")
+    fips_files(varying.def.sc)
+
+    fips_src(bgfx/examples/common/nanovg GROUP "nanovg")
     bgfx_shaders(FILES fs_nanovg_fill.sc vs_nanovg_fill.sc)
-    fips_files(
-        fontstash.h
-        nanovg.cpp nanovg.h
-        nanovg_bgfx.cpp
-        varying.def.sc
-    )
-    fips_dir(bgfx/examples/common/font GROUP "font")
+    fips_files(varying.def.sc)
+    fips_src(bgfx/examples/common/font GROUP "font")
     bgfx_shaders(FILES
         fs_font_basic.sc
         vs_font_basic.sc
@@ -373,19 +254,11 @@ fips_begin_lib(bgfx-examples-common)
         fs_font_distance_field_subpixel.sc
         vs_font_distance_field_subpixel.sc
     )
-    fips_files(
-        font_manager.cpp font_manager.h
-        text_buffer_manager.cpp text_buffer_manager.h
-        text_metrics.cpp text_metrics.h
-        utf8.cpp utf8.h varying.def.sc
-    )
+    fips_files(varying.def.sc)
+
     fips_dir(bgfx/examples/common/entry GROUP "entry")
-    fips_files(
-        cmd.cpp cmd.h
-        dbg.cpp dbg.h
-        entry.cpp entry.h entry_p.h
-        input.cpp input.h
-    )
+    fips_files(cmd.cpp cmd.h dbg.cpp dbg.h entry.cpp entry.h entry_p.h input.cpp input.h)
+    
     if (FIPS_ANDROID)
         fips_files(entry_android.cpp)
     elseif (FIPS_EMSCRIPTEN)
@@ -413,401 +286,44 @@ source_group("bx" FILES ${BX_FILES})
 
 #-[ Samples ]-------------------------------------------------------------------
 if (NOT FIPS_IMPORT)
+    fips_ide_group(Samples)
+    fips_include_directories(bgfx/examples/common)
+    fips_include_directories(${CMAKE_CURRENT_BINARY_DIR}/)
 
-fips_ide_group(Samples)
-fips_include_directories(bgfx/examples/common)
-fips_include_directories(${CMAKE_CURRENT_BINARY_DIR}/)
+    bgfx_app(00-helloworld)
+    bgfx_app(01-cubes)
+    bgfx_app(02-metaballs)
+    bgfx_app(03-raymarch)
+    bgfx_app(04-mesh)
+    bgfx_app(05-instancing)
+    bgfx_app(06-bump)
+    bgfx_app(07-callback)
+    bgfx_app(08-update)
+    bgfx_app(09-hdr)
+    bgfx_app(10-font)
+    bgfx_app(11-fontsdf)
+    bgfx_app(12-lod)
+    bgfx_app(15-shadowmaps-simple)
+    bgfx_app(17-drawstress)
+    bgfx_app(18-ibl)
+    bgfx_app(19-oit)
+    bgfx_app(20-nanovg)
+    bgfx_app(21-deferred)
+    bgfx_app(22-windows)
+    bgfx_app(23-vectordisplay)
+    bgfx_app(24-nbody)
+    bgfx_app(25-c99)
+    bgfx_app(26-occlusion)
+    bgfx_app(27-terrain)
 
-fips_begin_app(00-helloworld windowed)
-    fips_dir(bgfx/examples/00-helloworld GROUP ".")
-    fips_files(helloworld.cpp logo.h)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(01-cubes windowed)
-    fips_dir(bgfx/examples/01-cubes GROUP ".")
-    fips_files(cubes.cpp varying.def.sc)
-    fips_files(fs_cubes.sc vs_cubes.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(02-metaballs windowed)
-    fips_dir(bgfx/examples/02-metaballs GROUP ".")
-    fips_files(metaballs.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_metaballs.sc vs_metaballs.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(03-raymarch windowed)
-    fips_dir(bgfx/examples/03-raymarch GROUP ".")
-    fips_files(raymarch.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_raymarching.sc vs_raymarching.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(04-mesh windowed)
-    fips_dir(bgfx/examples/04-mesh GROUP ".")
-    fips_files(mesh.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_mesh.sc vs_mesh.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(05-instancing windowed)
-    fips_dir(bgfx/examples/05-instancing GROUP ".")
-    fips_files(instancing.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_instancing.sc vs_instancing.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(06-bump windowed)
-    fips_dir(bgfx/examples/06-bump GROUP ".")
-    fips_files(bump.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_bump.sc vs_bump.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(07-callback windowed)
-    fips_dir(bgfx/examples/07-callback GROUP ".")
-    fips_files(callback.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_callback.sc vs_callback.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(08-update windowed)
-    fips_dir(bgfx/examples/08-update GROUP ".")
-    fips_files(update.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_update.sc fs_update_cmp.sc vs_update.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(09-hdr windowed)
-    fips_dir(bgfx/examples/09-hdr GROUP ".")
-    fips_files(hdr.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_hdr_blur.sc    vs_hdr_blur.sc
-        fs_hdr_bright.sc  vs_hdr_bright.sc
-        fs_hdr_lum.sc     vs_hdr_lum.sc
-        fs_hdr_lumavg.sc  vs_hdr_lumavg.sc
-        fs_hdr_mesh.sc    vs_hdr_mesh.sc
-        fs_hdr_skybox.sc  vs_hdr_skybox.sc
-        fs_hdr_tonemap.sc vs_hdr_tonemap.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(10-font windowed)
-    fips_dir(bgfx/examples/10-font GROUP ".")
-    fips_files(font.cpp)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(11-fontsdf windowed)
-    fips_dir(bgfx/examples/11-fontsdf GROUP ".")
-    fips_files(fontsdf.cpp)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(12-lod windowed)
-    fips_dir(bgfx/examples/12-lod GROUP ".")
-    fips_files(lod.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_tree.sc vs_tree.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-if (NOT FIPS_EMSCRIPTEN AND NOT FIPS_PNACL)
-fips_begin_app(13-stencil windowed)
-    fips_dir(bgfx/examples/13-stencil GROUP ".")
-    fips_files(stencil.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_stencil_color_black.sc
-        fs_stencil_color_lighting.sc
-        fs_stencil_color_texture.sc
-        fs_stencil_texture.sc
-        fs_stencil_texture_lighting.sc
-        vs_stencil_color.sc
-        vs_stencil_color_lighting.sc
-        vs_stencil_color_texture.sc
-        vs_stencil_texture.sc
-        vs_stencil_texture_lighting.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-endif()
-
-if (NOT FIPS_EMSCRIPTEN AND NOT FIPS_PNACL)
-fips_begin_app(14-shadowvolumes windowed)
-    fips_dir(bgfx/examples/14-shadowvolumes GROUP ".")
-    fips_files(shadowvolumes.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_shadowvolume_color_lighting.sc
-        fs_shadowvolume_color_texture.sc
-        fs_shadowvolume_svbackblank.sc
-        fs_shadowvolume_svbackcolor.sc
-        fs_shadowvolume_svbacktex1.sc
-        fs_shadowvolume_svbacktex2.sc
-        fs_shadowvolume_svfrontblank.sc
-        fs_shadowvolume_svfrontcolor.sc
-        fs_shadowvolume_svfronttex1.sc
-        fs_shadowvolume_svfronttex2.sc
-        fs_shadowvolume_svside.sc
-        fs_shadowvolume_svsideblank.sc
-        fs_shadowvolume_svsidecolor.sc
-        fs_shadowvolume_svsidetex.sc
-        fs_shadowvolume_texture.sc
-        fs_shadowvolume_texture_lighting.sc
-        vs_shadowvolume_color_lighting.sc
-        vs_shadowvolume_color_texture.sc
-        vs_shadowvolume_svback.sc
-        vs_shadowvolume_svfront.sc
-        vs_shadowvolume_svside.sc
-        vs_shadowvolume_texture.sc
-        vs_shadowvolume_texture_lighting.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-endif()
-
-fips_begin_app(15-shadowmaps-simple windowed)
-    fips_dir(bgfx/examples/15-shadowmaps-simple GROUP ".")
-    fips_files(shadowmaps_simple.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_sms_mesh.sc
-        fs_sms_mesh_pd.sc
-        fs_sms_shadow.sc
-        #fs_sms_shadow.sh
-        fs_sms_shadow_pd.sc
-        vs_sms_mesh.sc
-        vs_sms_shadow.sc
-        vs_sms_shadow_pd.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-if (NOT FIPS_EMSCRIPTEN AND NOT FIPS_PNACL)
-fips_begin_app(16-shadowmaps windowed)
-    fips_dir(bgfx/examples/16-shadowmaps GROUP ".")
-    fips_files(shadowmaps.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_shadowmaps_color_black.sc
-        #fs_shadowmaps_color_lighting.sh
-        fs_shadowmaps_color_lighting_esm.sc
-        fs_shadowmaps_color_lighting_esm_csm.sc
-        fs_shadowmaps_color_lighting_esm_linear.sc
-        fs_shadowmaps_color_lighting_esm_linear_csm.sc
-        fs_shadowmaps_color_lighting_esm_linear_omni.sc
-        fs_shadowmaps_color_lighting_esm_omni.sc
-        fs_shadowmaps_color_lighting_hard.sc
-        fs_shadowmaps_color_lighting_hard_csm.sc
-        fs_shadowmaps_color_lighting_hard_linear.sc
-        fs_shadowmaps_color_lighting_hard_linear_csm.sc
-        fs_shadowmaps_color_lighting_hard_linear_omni.sc
-        fs_shadowmaps_color_lighting_hard_omni.sc
-        #fs_shadowmaps_color_lighting_main.sh
-        fs_shadowmaps_color_lighting_pcf.sc
-        fs_shadowmaps_color_lighting_pcf_csm.sc
-        fs_shadowmaps_color_lighting_pcf_linear.sc
-        fs_shadowmaps_color_lighting_pcf_linear_csm.sc
-        fs_shadowmaps_color_lighting_pcf_linear_omni.sc
-        fs_shadowmaps_color_lighting_pcf_omni.sc
-        fs_shadowmaps_color_lighting_vsm.sc
-        fs_shadowmaps_color_lighting_vsm_csm.sc
-        fs_shadowmaps_color_lighting_vsm_linear.sc
-        fs_shadowmaps_color_lighting_vsm_linear_csm.sc
-        fs_shadowmaps_color_lighting_vsm_linear_omni.sc
-        fs_shadowmaps_color_lighting_vsm_omni.sc
-        fs_shadowmaps_color_texture.sc
-        fs_shadowmaps_hblur.sc
-        fs_shadowmaps_hblur_vsm.sc
-        fs_shadowmaps_packdepth.sc
-        fs_shadowmaps_packdepth_linear.sc
-        fs_shadowmaps_packdepth_vsm.sc
-        fs_shadowmaps_packdepth_vsm_linear.sc
-        fs_shadowmaps_texture.sc
-        fs_shadowmaps_unpackdepth.sc
-        fs_shadowmaps_unpackdepth_vsm.sc
-        fs_shadowmaps_vblur.sc
-        fs_shadowmaps_vblur_vsm.sc
-        vs_shadowmaps_color.sc
-        vs_shadowmaps_color_lighting.sc
-        vs_shadowmaps_color_lighting_csm.sc
-        vs_shadowmaps_color_lighting_linear.sc
-        vs_shadowmaps_color_lighting_linear_csm.sc
-        vs_shadowmaps_color_lighting_linear_omni.sc
-        vs_shadowmaps_color_lighting_omni.sc
-        vs_shadowmaps_color_texture.sc
-        vs_shadowmaps_depth.sc
-        vs_shadowmaps_hblur.sc
-        vs_shadowmaps_packdepth.sc
-        vs_shadowmaps_packdepth_linear.sc
-        vs_shadowmaps_texture.sc
-        vs_shadowmaps_texture_lighting.sc
-        vs_shadowmaps_unpackdepth.sc
-        vs_shadowmaps_vblur.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-endif()
-
-fips_begin_app(17-drawstress windowed)
-    fips_dir(bgfx/examples/17-drawstress GROUP ".")
-    fips_files(drawstress.cpp varying.def.sc)
-    bgfx_shaders(FILES fs_drawstress.sc vs_drawstress.sc)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(18-ibl windowed)
-    fips_dir(bgfx/examples/18-ibl GROUP ".")
-    fips_files(ibl.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_ibl_mesh.sc   vs_ibl_mesh.sc
-        fs_ibl_skybox.sc vs_ibl_skybox.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(19-oit windowed)
-    fips_dir(bgfx/examples/19-oit GROUP ".")
-    fips_files(oit.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_oit.sc
-        fs_oit_wb.sc
-        fs_oit_wb_blit.sc
-        fs_oit_wb_separate.sc
-        fs_oit_wb_separate_blit.sc
-        vs_oit.sc
-        vs_oit_blit.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(20-nanovg windowed)
-    fips_dir(bgfx/examples/20-nanovg GROUP ".")
-    fips_files(nanovg.cpp blendish.h)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(21-deferred windowed)
-    fips_dir(bgfx/examples/21-deferred GROUP ".")
-    fips_files(deferred.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        fs_deferred_combine.sc
-        fs_deferred_debug.sc
-        fs_deferred_debug_line.sc
-        fs_deferred_geom.sc
-        fs_deferred_light.sc
-        vs_deferred_combine.sc
-        vs_deferred_debug.sc
-        vs_deferred_debug_line.sc
-        vs_deferred_geom.sc
-        vs_deferred_light.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(22-windows windowed)
-    fips_dir(bgfx/examples/22-windows GROUP ".")
-    fips_files(windows.cpp)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(23-vectordisplay windowed)
-    fips_dir(bgfx/examples/23-vectordisplay GROUP ".")
-    fips_files(
-        main.cpp
-        vectordisplay.cpp
-        vectordisplay.h
-        varying.def.sc
-    )
-    bgfx_shaders(FILES
-        fs_vectordisplay_blit.sc
-        fs_vectordisplay_blur.sc
-        fs_vectordisplay_fb.sc
-        vs_vectordisplay_fb.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-#
-# Need fix compute shader compilation
-#
-fips_begin_app(24-nbody windowed)
-    fips_dir(bgfx/examples/24-nbody GROUP ".")
-    fips_files(nbody.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        cs_init_instances.sc
-        cs_update_instances.sc
-        fs_particle.sc
-        vs_particle.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(25-c99 windowed)
-    fips_dir(bgfx/examples/25-c99 GROUP ".")
-    fips_files(helloworld.c)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(26-occlusion windowed)
-    fips_dir(bgfx/examples/26-occlusion GROUP ".")
-    fips_files(occlusion.cpp)
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-fips_begin_app(27-terrain windowed)
-    fips_dir(bgfx/examples/27-terrain GROUP ".")
-    fips_files(terrain.cpp varying.def.sc)
-    bgfx_shaders(FILES
-        vs_terrain.sc
-        vs_terrain_height_texture.sc
-        fs_terrain.sc
-    )
-    fips_deps(bgfx bgfx-imgui bgfx-ib-compress bgfx-examples-common)
-fips_end_app()
-
-#
-# Force windows entry point to use main() with subsystem:windows
-#
-if(FIPS_MSVC)
-    set(bgfx_samples
-        00-helloworld
-        01-cubes
-        02-metaballs
-        03-raymarch
-        04-mesh
-        05-instancing
-        06-bump
-        07-callback
-        08-update
-        09-hdr
-        10-font
-        11-fontsdf
-        12-lod
-        13-stencil
-        14-shadowvolumes
-        15-shadowmaps-simple
-        16-shadowmaps
-        17-drawstress
-        18-ibl
-        19-oit
-        20-nanovg
-        21-deferred
-        22-windows
-        23-vectordisplay
-        24-nbody
-        25-c99
-        27-terrain
-        26-occlusion
-    )
-    foreach (bgfx_sample ${bgfx_samples})
-        set_target_properties(${bgfx_sample} PROPERTIES LINK_FLAGS "/ENTRY:\"mainCRTStartup\"")
-    endforeach()
-endif()
-
+    if (NOT FIPS_EMSCRIPTEN AND NOT FIPS_PNACL)
+        bgfx_app(13-stencil)
+        bgfx_app(14-shadowvolumes)
+        bgfx_app(16-shadowmaps)
+    endif()
 
 endif() # NOT FIPS_IMPORT
 
 if (NOT FIPS_IMPORT)
     fips_finish()
 endif()
-

--- a/fips-include.cmake
+++ b/fips-include.cmake
@@ -71,7 +71,7 @@ macro(bgfx_app name)
     endif()
 
     if (NOT _bs_DEPS)
-        set(_bs_DEPS bgfx-imgui bgfx-ib-compress bgfx-examples-common)
+        set(_bs_DEPS bgfx-examples-common bgfx-imgui bgfx-ib-compress)
     endif()
 
     file(TO_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${_bs_PATH} _bs_relative)


### PR DESCRIPTION
Added a function to simplify adding samples to the project.
This may also be used to declare simple windowed application that follows the bgfx samples structure when importing fips-bgfx from other projects.
